### PR TITLE
Add global dependencies as local dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,17 @@
   "directories": {
     "example": "examples"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "beefy": "^2.1.5",
+    "browserify": "^9.0.8",
     "es6ify": "^1.6.0",
     "grunt": "~0.4.5",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",
-    "grunt-contrib-uglify": "~0.7.0"
+    "grunt-contrib-uglify": "~0.7.0",
+    "nodemon": "^1.3.7"
   },
-  "devDependencies": {},
   "browserify": {
     "transforms": ["es6ify"]
   },


### PR DESCRIPTION
This way, all of the `npm run *` commands can be run without any tools, like browserify or nodemon, to be installed globally.

I found this fork via the issue over on the main one, and am really interested in using meyda via npm / require.

By the way, is grunt actually needed for this project?